### PR TITLE
Fix messages format 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ module.exports = class automator {
       reportMethod: 'slack',
     }, options);
     this.options.driver = options.driver || automator.DRIVER_WEBDRIVERIO;
+    this.options.persona.message = this.options.persona.message.replace(/(\r\n|\n|\r)/gm, '\r\n');
     this.errors = [];
     this.graph = new Graph(this.options, {
       nodes: 'steps',


### PR DESCRIPTION
* This change all kind of message to `\r\n` this way the Chromeless add the proper blank space in the message 

<img width="492" alt="screen shot 2018-01-05 at 12 01 16 pm" src="https://user-images.githubusercontent.com/4040060/34619442-26be3946-f210-11e7-9369-a20cd7a29f8b.png">
